### PR TITLE
Add Playwright login test and env-configurable SignInPage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "td-automation-project",
   "version": "1.0.0",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "playwright test",
+    "test:login": "playwright test tests/login.spec.ts"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/page-objects/signin-page.ts
+++ b/page-objects/signin-page.ts
@@ -1,19 +1,19 @@
-import { Page } from 'playwright';
+import type { Page } from '@playwright/test';
 
 export class SignInPage {
-    readonly page: Page;
+  readonly page: Page;
 
-    constructor(page: Page) {
-        this.page = page;
-    }
+  constructor(page: Page) {
+    this.page = page;
+  }
 
-    public async signInToAdminPage() {
-        await this.page.getByLabel('email').fill('kathyas@nicasource.com');
-        await this.page.getByRole('textbox', { name: 'Password' }).fill('Kat1901!');
-        await this.page.getByRole('button', { name: 'Sign in' }).click();
-        await this.page.waitForURL(/#\/Dashboard$/);
+  public async signInToAdminPage(email?: string, password?: string) {
+    const loginEmail = email ?? process.env.LOGIN_EMAIL ?? 'kathyas@nicasource.com';
+    const loginPassword = password ?? process.env.LOGIN_PASSWORD ?? 'Kat1901!';
 
-    }
-
-    
+    await this.page.getByLabel('email').fill(loginEmail);
+    await this.page.getByRole('textbox', { name: 'Password' }).fill(loginPassword);
+    await this.page.getByRole('button', { name: 'Sign in' }).click();
+    await this.page.waitForURL(/#\/Dashboard$/);
+  }
 }

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { SignInPage } from '../page-objects/signin-page';
+
+test.describe('Login', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('should sign in and land on dashboard', async ({ page }) => {
+    const signInPage = new SignInPage(page);
+
+    await signInPage.signInToAdminPage();
+
+    await expect(page).toHaveURL(/#\/Dashboard$/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a dedicated, reusable login test to validate signing into the admin dashboard.
- Make the sign-in page object more flexible by supporting injected credentials and environment-variable fallbacks.
- Add convenient npm scripts to run the full suite or the single login spec.

### Description
- Added a new test file `tests/login.spec.ts` which navigates to the app, uses the `SignInPage` page object to perform sign-in, and asserts the URL includes `#/Dashboard`.
- Refactored `page-objects/signin-page.ts` to import Playwright types from `@playwright/test`, accept optional `email` and `password` parameters, and fallback to `process.env.LOGIN_EMAIL` / `process.env.LOGIN_PASSWORD` or defaults.
- Updated `package.json` to add `scripts.test` (`playwright test`) and `scripts["test:login"]` (`playwright test tests/login.spec.ts`).

### Testing
- Ran `npx playwright test tests/login.spec.ts --list` and it successfully listed the three browser tests (chromium, firefox, webkit). 
- The listing returned an npm warning about unknown env config `http-proxy` which is non-blocking and did not prevent test listing from succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f20569e0832a83539bbbbe6f9de5)