### PR TITLE
Update navigation tests to use Earnings menu label

### DIFF
--- a/page-objects/navigation.ts
+++ b/page-objects/navigation.ts
@@ -23,8 +23,8 @@ export class Navigation {
     }
 
     public async navigateToCommissions() {
-        await this.page.getByRole('menuitem', { name: 'Commissions' }).click();
-        await this.page.waitForURL(/#\/Commissions$/);
+        await this.page.getByRole('menuitem', { name: 'Earnings' }).click();
+        await this.page.waitForURL(/#\/(?:Commissions|Earnings)$/);
     }
 
     public async navigateToPayments() {

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -27,10 +27,10 @@ test('navigate to orders page', async ({ page }) => {
     await expect(page).toHaveURL(/\/#\/Orders\/?(?:\?.*)?$/);
 });
 
-test('navigate to commissions page', async ({ page }) => {
+test('navigate to earnings page', async ({ page }) => {
   const navigateTo = new Navigation(page);
   await navigateTo.navigateToCommissions();
-  await expect(page).toHaveURL(/\/#\/Commissions$/);
+  await expect(page).toHaveURL(/\/#\/(?:Commissions|Earnings)$/);
 });
 
 test('navigate to payments page', async ({ page }) => {


### PR DESCRIPTION
### Motivation
- The UI renamed the "Commissions" menu item to "Earnings", causing a timeout when tests tried to click `menuitem[name='Commissions']`.
- Tests should be resilient to the transition so CI doesn't fail while the app or test data settle.

### Description
- Changed `page-objects/navigation.ts` `navigateToCommissions` to click the `Earnings` menu item and to wait for a URL matching the tolerant regex ``/#\/(?:Commissions|Earnings)$/``.
- Updated `tests/navigation.spec.ts` test title from `navigate to commissions page` to `navigate to earnings page` and adjusted its URL assertion to use ``/#\/(?:Commissions|Earnings)$/``.
- No other tests or helpers were modified.

### Testing
- Attempted `npm test -- tests/navigation.spec.ts --project=chromium`, which failed because the project has no `test` script defined, so the command errored out.
- Ran `npx playwright test tests/navigation.spec.ts --project=chromium`, which failed because Playwright browser binaries are not installed in the environment and `npx playwright install` is required; tests did not execute.
- No passing Playwright runs were available in this environment due to missing browser installation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90f7f7130832a871e992787bdbfaf)